### PR TITLE
fix: patch isProposedAPIEnabled to always be true

### DIFF
--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -134,10 +134,15 @@ export interface IExtensionHost {
 }
 
 export function isProposedApiEnabled(extension: IExtensionDescription, proposal: ApiProposalName): boolean {
-	if (!extension.enabledApiProposals) {
-		return false;
-	}
-	return extension.enabledApiProposals.includes(proposal);
+	/**
+	 * The Jupyter extension uses proposed APIs
+	 * but has a version that doesn't enable it correctly.
+	 *
+	 * This patch ensures that we default to enabling
+	 * the proposed API.
+	 * @author coder
+	 */
+	return true
 }
 
 export function checkProposedApiEnabled(extension: IExtensionDescription, proposal: ApiProposalName): void {


### PR DESCRIPTION
This PR patches VS Code to always assume the proposed API is enabled. We were already doing this https://github.com/coder/vscode/commit/a9ea411918c8db3a02820c43ee290b6e2569f418 but for some reason, that change wasn't working with one of the Jupyter versions so we had to patch it here.

This shouldn't cause any regressions or instability as far as we can tell. 

H/T to @bryphe-coder who actually found and suggested this patch.

Fixes https://github.com/coder/code-server/issues/3782
