### PR TITLE
fix: use remoteAuthority with URIs for accuracy

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -440,12 +440,17 @@ class WindowIndicator implements IWindowIndicator {
 	/**
 	 * If the value begins with a slash assume it is a file path and convert it to
 	 * use the vscode-remote scheme.
+	 * 
+	 * We also add the remote authority in toRemote. It needs to be accurate
+	 * otherwise other URIs won't match it, leading to issues such as this one:
+	 * https://github.com/coder/code-server/issues/4630
 	 *
 	 * @author coder
 	 */
+	const remoteAuthority = location.host
 	const toRemote = (value: string): string => {
 		if (value.startsWith('/')) {
-			return 'vscode-remote://' + value;
+			return 'vscode-remote://' + remoteAuthority + value;
 		}
 		return value;
 	};
@@ -564,7 +569,7 @@ class WindowIndicator implements IWindowIndicator {
 		 * determine this reliably on the backend.
 		 * @author coder
 		 */
-		remoteAuthority: location.host,
+		remoteAuthority,
 		/**
 		 * Override relative URLs in the product configuration against the window
 		 * location as necessary. Only paths that must be absolute need to be


### PR DESCRIPTION
This PR fixes an issue where the File Explorer wasn't showing newly created files created from the Integrated Terminal. This happened because we weren't including the authority in the URI causing VS Code to think it should not refresh the File Explorer view.

By including the authority, the URI is accurate and everything works as expected.

Solved with @code-asher 

Fixes https://github.com/coder/code-server/issues/4630
