### PR TITLE
Bypass spurious reload button

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -1443,9 +1443,17 @@ export class ReloadAction extends ExtensionAction {
 						if (extensionInOtherServer) {
 							// This extension prefers to run on UI/Local side but is running in remote
 							if (runningExtensionServer === this.extensionManagementServerService.remoteExtensionManagementServer && this.extensionManifestPropertiesService.prefersExecuteOnUI(this.extension.local!.manifest)) {
-								this.enabled = true;
-								this.label = localize('reloadRequired', "Reload Required");
-								this.tooltip = localize('enable locally', "Please reload Visual Studio Code to enable this extension locally.");
+								/**
+								 * This is causing builtin extensions to always show a reload
+								 * button yet reloading does nothing.
+								 * TODO@coder: The real problem might be that these extensions
+								 * are somehow supposed to be running as web extensions instead
+								 * of in the remote but it is unclear how to make that happen.
+								 * @author coder
+								 */
+								// this.enabled = true;
+								// this.label = localize('reloadRequired', "Reload Required");
+								// this.tooltip = localize('enable locally', "Please reload Visual Studio Code to enable this extension locally.");
 								return;
 							}
 


### PR DESCRIPTION
This reload button does nothing which I think must mean there is some
logic somewhere that is supposed to load these extensions locally that
is not working or not implemented.

Until we find it bypassing is probably a good move because otherwise it
makes it look like the extension is not running and working even though
it really is (it is just running remotely).

This will be a temporary measure to solve
https://github.com/coder/code-server/issues/4600.

As an aside, I tried upgrading to VS Code 1.63.2 but the problem persisted.
