### PR TITLE
Use single bracket pair for proxy url template

### DIFF
--- a/src/vs/server/webClientServer.ts
+++ b/src/vs/server/webClientServer.ts
@@ -320,7 +320,7 @@ export class WebClientServer {
 					// Endpoints
 					base,
 					logoutEndpointUrl: base + '/logout',
-					proxyEndpointUrlTemplate: base + '/proxy/{{port}}',
+					proxyEndpointUrlTemplate: base + '/proxy/{port}',
 					webEndpointUrl: vscodeBase + '/static',
 					webEndpointUrlTemplate: vscodeBase + '/static',
 					webviewContentExternalBaseUrlTemplate: vscodeBase + '/webview/{{uuid}}/',


### PR DESCRIPTION
I used two because it matches VS Code's own URL templates but at least
one extension already implemented the use of VSCODE_PROXY_URI under the
assumption it contains a single bracket pair so doing this would break
existing instances with that extension installed.