### PR TITLE
Use double brackets for proxy url template

### DIFF
--- a/src/vs/server/webClientServer.ts
+++ b/src/vs/server/webClientServer.ts
@@ -75,7 +75,7 @@ export class WebClientServer {
 
 	private _mapCallbackUriToRequestId: Map<string, UriComponents> = new Map();
 
-	constructor (
+	constructor(
 		private readonly _connectionToken: string,
 		private readonly _environmentService: IServerEnvironmentService,
 		private readonly _logService: ILogService,
@@ -320,7 +320,7 @@ export class WebClientServer {
 					// Endpoints
 					base,
 					logoutEndpointUrl: base + '/logout',
-					proxyEndpointUrlTemplate: base + '/proxy/{port}',
+					proxyEndpointUrlTemplate: base + '/proxy/{{port}}',
 					webEndpointUrl: vscodeBase + '/static',
 					webEndpointUrlTemplate: vscodeBase + '/static',
 					webviewContentExternalBaseUrlTemplate: vscodeBase + '/webview/{{uuid}}/',


### PR DESCRIPTION
This PR resolves https://github.com/coder/code-server/issues/1510#issuecomment-1005876980: @code-asher Double brackets may be used now to match VS Code's own templating scheme.

https://github.com/REditorSupport/vscode-R/pull/934 has been accepted and released with [R Extension v2.3.6](https://github.com/REditorSupport/vscode-R/releases/tag/v2.3.6).