### PR TITLE
Make unique database per location

### DIFF
--- a/src/vs/platform/storage/browser/storageService.ts
+++ b/src/vs/platform/storage/browser/storageService.ts
@@ -220,6 +220,7 @@ export class IndexedDBStorageDatabase extends Disposable implements IIndexedDBSt
 		 * different machines that share the same domain and file path from
 		 * colliding (since it does not appear IndexedDB can be scoped to a path) as
 		 * long as they are hosted on different paths.
+		 * @author coder
 		 */
 		const windowId = hash(location.pathname.toString()).toString(16);
 		this.name = `${IndexedDBStorageDatabase.STORAGE_DATABASE_PREFIX}${windowId}-${options.id}`;


### PR DESCRIPTION
This fixes collisions where VS Code is serving a workspace with the same
name but on a different machine and hosted on the same domain.

I have an e2e test for this on the code-server side.