### PR TITLE
Make the --github-auth flag work for extensions

### DIFF
--- a/src/vs/server/webClientServer.ts
+++ b/src/vs/server/webClientServer.ts
@@ -295,7 +295,12 @@ export class WebClientServer {
 			id: generateUuid(),
 			providerId: 'github',
 			accessToken: this._environmentService.args['github-auth'],
-			scopes: [['user:email'], ['repo']]
+			/**
+			 * Add a set of scopes for the pull request extension which also wants
+			 * read:user.
+			 * @author coder
+			 */
+			scopes: [['read:user', 'user:email', 'repo'], ['user:email'], ['repo']]
 		} : undefined;
 
 		const locale = this._environmentService.args.locale || await getLocaleFromConfig(this._environmentService.argvResource);


### PR DESCRIPTION
I was hoping the existing `--github-auth` flag would just work but it did not.  Extensions seems to use a completely different credential entry for some reason so I have it inserting one that matches.  I tested the pull request extension and GitLens.

There will be a companion PR shortly to make this work with code-server.

I am very unsure as to whether this is the right way to handle it.